### PR TITLE
added CARAVAN_TIMEOUT_CMD option

### DIFF
--- a/caravan/JobConsumer.x10
+++ b/caravan/JobConsumer.x10
@@ -101,7 +101,8 @@ class JobConsumer {
     val taskId = task.taskId;
     val startAt = m_timer.milliTime();
     val runPlace = here.id;
-    val rcResults = task.run();
+    val duration = remainingTimeInSec();
+    val rcResults = task.run(duration, m_logger);
     val rc = rcResults.first;
     val results = rcResults.second;
     val finishAt = m_timer.milliTime();
@@ -128,6 +129,13 @@ class JobConsumer {
         }
       }
     });
+  }
+
+  private def remainingTimeInSec(): Long {
+    if( m_timeOut <= 0 ) { return -1; }
+    else {
+      return (m_timeOut - m_timer.milliTime())/1000 as Long;
+    }
   }
 
   private def isExpired(): Boolean {

--- a/caravan/OptionParser.x10
+++ b/caravan/OptionParser.x10
@@ -10,6 +10,7 @@ public class OptionParser {
     ["CARAVAN_TIMEOUT", "timeout duration in sec", "86400"],
     ["CARAVAN_SEND_RESULT_INTERVAL", "interval to send results in sec", "3"],
     ["CARAVAN_WORK_BASE_DIR", "the directory under which work directories are created", "."],
+    ["CARAVAN_TIMEOUT_CMD", "timeout command. If the system has 'timeout' or 'gtimeout', specify it. You may also add an option like 'timeout -k 30'. If this is not given, timeout is not used.", ""],
     ["CARAVAN_LOG_LEVEL", "log level", "1"]
   ];
 

--- a/test/OptionParserTest.x10
+++ b/test/OptionParserTest.x10
@@ -20,7 +20,8 @@ class OptionParserTest {
     assert OptionParser.getLong("CARAVAN_TIMEOUT") == Long.parse(opts(1)(2));
     assert OptionParser.getLong("CARAVAN_SEND_RESULT_INTERVAL") == Long.parse(opts(2)(2));
     assert OptionParser.getString("CARAVAN_WORK_BASE_DIR") == opts(3)(2);
-    assert OptionParser.getLong("CARAVAN_LOG_LEVEL") == Long.parse(opts(4)(2));
+    assert OptionParser.getString("CARAVAN_TIMEOUT_CMD") == opts(4)(2);
+    assert OptionParser.getLong("CARAVAN_LOG_LEVEL") == Long.parse(opts(5)(2));
 
     val detected = OptionParser.detectedOptions();
     assert detected.size() == 0 : detected;

--- a/test/TaskTest.x10
+++ b/test/TaskTest.x10
@@ -1,6 +1,7 @@
 package test;
 
 import caravan.Task;
+import caravan.Logger;
 import x10.io.File;
 
 class TaskTest {
@@ -32,7 +33,7 @@ class TaskTest {
     p( task.toString() );
     assert task.taskId == taskId;
 
-    val out = task.run();
+    val out = task.run(-1, new Logger(0));
 
     assert out.first == 0;
     assert cmp(out.second, [132.0, 1.0, 2.0, 3.0, 1234.0]) : out.second;
@@ -50,7 +51,7 @@ class TaskTest {
     val task = Task( taskId, cmd );
 
     assert task.taskId == taskId;
-    val out = task.run();
+    val out = task.run(-1, new Logger(0));
 
     assert out.first == 0;
     assert out.second.size == 0; // empty Rail


### PR DESCRIPTION
`CARAVAN_TIMEOUT_CMD`オプションを追加。

`export CARAVAN_TIMEOUT_CMD=timeout` と指定すると、timeoutに渡す引数をフレームワークで計算して `timeout #{duration} #{cmd}` という形式で実行する。

システムが"gtimeout"コマンドを持つ場合は、`export CARAVAN_TIMEOUT_CMD=timeout`と指定する。

また引数を指定することも可能。例えば、

`export CARAVAN_TIMEOUT_CMD=timeout -k 30` というように指定しておくと、シグナルを送って30秒たってもプロセスが終了していない場合にSIGKILLを送る。

環境変数が指定されていなければ、timeoutなしでコマンドを実行する。
